### PR TITLE
fix clippy, update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,14 @@ serde_json = "1.0"
 base64 = "0.11"
 futures = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
-reqwest = { version = "0.10", features = ["json", "stream"] }
+reqwest = { version = "0.12.7", features = ["json", "stream", "multipart"] }
 tempdir = "0.3"
 anyhow = "1.0"
 dirs = "2.0"
-tokio = { version = "0.2", features = ["fs", "io-util"] }
-tokio-util = { version = "0.3", features = ["codec"] }
-bytes = "0.5"
-zip = "0.5"
+tokio = { version = "1.40.0", features = ["fs", "io-util", "rt-multi-thread"] }
+tokio-util = { version = "0.7.12", features = ["codec"] }
+bytes = "1.7.1"
+zip = "2.2.0"
 thiserror = "1.0"
 tar = "0.4"
 walkdir = "2.3"
@@ -37,5 +37,5 @@ log = "0.4.8"
 flate2 = "1.0"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.40.0", features = ["macros"] }
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -7,7 +7,7 @@ use std::iter::Iterator;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 use walkdir::{DirEntry, WalkDir};
-use zip::write::FileOptions;
+use zip::write::SimpleFileOptions;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ArchiveMode {
@@ -98,7 +98,7 @@ where
 {
     let prefix = prefix.as_ref();
     let mut zip = zip::ZipWriter::new(writer);
-    let options = FileOptions::default().unix_permissions(0o755);
+    let options = SimpleFileOptions::default().unix_permissions(0o755);
 
     let mut buffer = Vec::new();
     for entry in it {

--- a/src/models/extended.rs
+++ b/src/models/extended.rs
@@ -328,12 +328,12 @@ pub struct DownloadResponse {
 }
 
 mod date_serializer {
-    use chrono::{DateTime, NaiveDateTime, Utc};
+    use chrono::{DateTime, NaiveDateTime};
     use serde::de::Error;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     fn time_to_json(t: NaiveDateTime) -> String {
-        DateTime::<Utc>::from_utc(t, Utc).to_rfc3339()
+        t.and_utc().to_rfc3339()
     }
 
     pub fn serialize<S: Serializer>(
@@ -347,19 +347,19 @@ mod date_serializer {
         deserializer: D,
     ) -> Result<NaiveDateTime, D::Error> {
         let time: String = Deserialize::deserialize(deserializer)?;
-        Ok(DateTime::parse_from_rfc3339(&time)
+        DateTime::parse_from_rfc3339(&time)
             .map(|d| d.naive_utc())
-            .map_err(D::Error::custom)?)
+            .map_err(D::Error::custom)
     }
 }
 
 mod date_serializer_opt {
-    use chrono::{DateTime, NaiveDateTime, Utc};
+    use chrono::{DateTime, NaiveDateTime};
     use serde::de::Error;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     fn time_to_json(t: NaiveDateTime) -> String {
-        DateTime::<Utc>::from_utc(t, Utc).to_rfc3339()
+        t.and_utc().to_rfc3339()
     }
 
     pub fn serialize<S: Serializer>(

--- a/src/models/metadata.rs
+++ b/src/models/metadata.rs
@@ -120,22 +120,22 @@ impl Metadata {
     }
 }
 
-impl Into<DatasetUpdateSettingsRequest> for Metadata {
-    fn into(self) -> DatasetUpdateSettingsRequest {
-        let mut settings = DatasetUpdateSettingsRequest::with_title(self.title)
-            .with_licenses(self.licenses)
-            .with_keywords(self.keywords)
-            .with_collaborators(self.collaborators);
-        if let Some(s) = self.subtitle {
+impl From<Metadata> for DatasetUpdateSettingsRequest {
+    fn from(val: Metadata) -> Self {
+        let mut settings = DatasetUpdateSettingsRequest::with_title(val.title)
+            .with_licenses(val.licenses)
+            .with_keywords(val.keywords)
+            .with_collaborators(val.collaborators);
+        if let Some(s) = val.subtitle {
             settings.set_subtitle(s);
         }
-        if let Some(p) = self.is_private {
+        if let Some(p) = val.is_private {
             settings.set_is_private(p);
         }
-        if let Some(d) = self.data {
+        if let Some(d) = val.data {
             settings.set_data(d);
         }
-        if let Some(desc) = self.description {
+        if let Some(desc) = val.description {
             settings.set_description(desc);
         }
         settings

--- a/src/query.rs
+++ b/src/query.rs
@@ -38,7 +38,9 @@ pub enum PushLanguageType {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum Language {
+    #[default]
     All,
     Python,
     R,
@@ -47,44 +49,35 @@ pub enum Language {
     Rmarkdown,
 }
 
-impl Default for Language {
-    fn default() -> Self {
-        Language::All
-    }
-}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum KernelType {
+    #[default]
     All,
     Script,
     Notebook,
 }
 
-impl Default for KernelType {
-    fn default() -> Self {
-        KernelType::All
-    }
-}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum OutputType {
+    #[default]
     All,
     Visualization,
     Data,
 }
 
-impl Default for OutputType {
-    fn default() -> Self {
-        OutputType::All
-    }
-}
 
 /// How to sort the result
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum SortBy {
+    #[default]
     Hotness,
     CommentCount,
     DateCreated,
@@ -96,30 +89,24 @@ pub enum SortBy {
     VoteCount,
 }
 
-impl Default for SortBy {
-    fn default() -> Self {
-        SortBy::Hotness
-    }
-}
 
 /// Competitoins valid types
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum CompetitionGroup {
+    #[default]
     General,
     Entered,
     InClass,
 }
 
-impl Default for CompetitionGroup {
-    fn default() -> Self {
-        CompetitionGroup::General
-    }
-}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum CompetitionCategory {
+    #[default]
     All,
     Featured,
     Research,
@@ -129,33 +116,27 @@ pub enum CompetitionCategory {
     Playground,
 }
 
-impl Default for CompetitionCategory {
-    fn default() -> Self {
-        CompetitionCategory::All
-    }
-}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum CompetitionSortBy {
     Grouped,
     Prize,
     EarliestDeadline,
+    #[default]
     LatestDeadline,
     NumberOfTeams,
     RecentlyCreated,
 }
 
-impl Default for CompetitionSortBy {
-    fn default() -> Self {
-        CompetitionSortBy::LatestDeadline
-    }
-}
 
 /// Datasets valid types
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum DatasetFileType {
+    #[default]
     All,
     Csv,
     Sqlite,
@@ -163,15 +144,12 @@ pub enum DatasetFileType {
     BigQuery,
 }
 
-impl Default for DatasetFileType {
-    fn default() -> Self {
-        DatasetFileType::All
-    }
-}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum DatasetLicenseName {
+    #[default]
     All,
     Cc,
     Gpl,
@@ -179,11 +157,6 @@ pub enum DatasetLicenseName {
     Other,
 }
 
-impl Default for DatasetLicenseName {
-    fn default() -> Self {
-        DatasetLicenseName::All
-    }
-}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -197,27 +170,21 @@ pub enum DatasetSortBy {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum Group {
+    #[default]
     Everyone,
     Profile,
 }
 
-impl Default for Group {
-    fn default() -> Self {
-        Group::Everyone
-    }
-}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub(crate) enum DatasetGroup {
+    #[default]
     Public,
     My,
     User,
 }
 
-impl Default for DatasetGroup {
-    fn default() -> Self {
-        DatasetGroup::Public
-    }
-}


### PR DESCRIPTION
Experimenting with Kaggle and received the error `not currently running on a Tokio 0.2.x runtime.` when attempting to download datasets with this crate. Found that updating dependencies fixed this. Also fixed clippy warnings.  Thank you for building this.